### PR TITLE
feat: Add Contact page to top navigation (en/zh)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -103,6 +103,7 @@ export default defineConfig({
           { text: 'NMPA', link: '/en/nmpa/' },
           { text: 'Standards', link: '/en/shared/standards' },
           { text: 'Insights', link: '/en/insights/' },
+          { text: 'Contact', link: '/en/contact' },
         ],
         sidebar: Object.assign(
           {
@@ -202,6 +203,7 @@ export default defineConfig({
           { text: 'NMPA', link: '/zh/nmpa/' },
           { text: '标准', link: '/zh/shared/standards' },
           { text: '法规解读', link: '/zh/insights/' },
+          { text: '联系我们', link: '/zh/contact' },
         ],
         sidebar: zhSidebar,
         socialLinks: [

--- a/docs/en/contact.md
+++ b/docs/en/contact.md
@@ -1,0 +1,57 @@
+---
+layout: page
+title: Contact Us
+---
+
+# Contact Us
+
+## About DocMCP
+
+DocMCP is a regulatory intelligence platform that helps medical device manufacturers navigate complex compliance requirements across global markets (EU MDR, FDA, NMPA).
+
+Our AI-powered tools streamline clinical evaluation, literature review, and regulatory documentation -- reducing months of manual work to days.
+
+## Get Started
+
+### Request an Invite Code
+
+DocMCP is currently available by invitation. To request access:
+
+1. Send an email to **[support@team-ra.org](mailto:support@team-ra.org)** with the subject line: **"DocMCP Invite Request"**
+2. Include the following information:
+   - Your name and organization
+   - Your role (e.g., Regulatory Affairs, Clinical Evaluation, Quality)
+   - A brief description of your use case
+3. We will review your request and respond within **2 business days**
+
+### Available Plans
+
+| Plan | Quota | Price |
+|------|-------|-------|
+| **Trial** | 500K tokens | Free (72 hours) |
+| **Basic** | 500K tokens/month | $10/month |
+| **Pro** | 2M tokens/month | $20/month |
+| **Max** | 10M tokens/month | $80/month |
+
+Annual subscriptions are available at a discount. Contact us for details.
+
+## Support
+
+- **Email**: [support@team-ra.org](mailto:support@team-ra.org)
+- **GitHub**: [RASAAS/docmcp-knowledge](https://github.com/RASAAS/docmcp-knowledge) (knowledge base issues & contributions)
+
+## Partnership & Collaboration
+
+We welcome collaboration with:
+
+- **Regulatory consultancies** looking to enhance their service capabilities
+- **Medical device manufacturers** seeking to streamline compliance workflows
+- **Notified Bodies and regulatory agencies** interested in AI-assisted review tools
+
+For partnership inquiries, contact **[business@team-ra.org](mailto:business@team-ra.org)**.
+
+## Legal
+
+- Knowledge base content is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+- DocMCP software and services are proprietary
+- [Privacy Policy](/en/privacy) | [Terms of Service](/en/terms)

--- a/docs/zh/contact.md
+++ b/docs/zh/contact.md
@@ -1,0 +1,57 @@
+---
+layout: page
+title: 联系我们
+---
+
+# 联系我们
+
+## 关于 DocMCP
+
+DocMCP 是一个法规智能平台，帮助医疗器械制造商应对全球市场（EU MDR、FDA、NMPA）的复杂合规要求。
+
+我们的 AI 工具可以简化临床评价、文献审查和法规文件编制流程 -- 将数月的手工工作缩短到数天。
+
+## 开始使用
+
+### 申请邀请码
+
+DocMCP 目前仅通过邀请注册。申请方式：
+
+1. 发送邮件至 **[support@team-ra.org](mailto:support@team-ra.org)**，主题为：**"DocMCP 邀请码申请"**
+2. 请附上以下信息：
+   - 姓名和所在机构
+   - 职务角色（如法规事务、临床评价、质量管理等）
+   - 简要描述您的使用场景
+3. 我们将在 **2 个工作日内** 审核并回复
+
+### 套餐方案
+
+| 套餐 | 额度 | 价格 |
+|------|------|------|
+| **试用版** | 50万 tokens | 免费（72 小时） |
+| **基础版** | 50万 tokens/月 | $10/月 |
+| **专业版** | 200万 tokens/月 | $20/月 |
+| **旗舰版** | 1000万 tokens/月 | $80/月 |
+
+年度订阅享受折扣，详情请联系我们。
+
+## 技术支持
+
+- **邮箱**: [support@team-ra.org](mailto:support@team-ra.org)
+- **GitHub**: [RASAAS/docmcp-knowledge](https://github.com/RASAAS/docmcp-knowledge)（知识库反馈与贡献）
+
+## 合作与商务
+
+我们欢迎以下合作：
+
+- **法规咨询机构** -- 增强服务能力
+- **医疗器械制造商** -- 简化合规工作流程
+- **公告机构和监管部门** -- AI 辅助审查工具
+
+商务合作请联系 **[business@team-ra.org](mailto:business@team-ra.org)**。
+
+## 法律声明
+
+- 知识库内容以 [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) 许可证授权
+- DocMCP 软件和服务为专有产品
+- [隐私政策](/zh/privacy) | [服务条款](/zh/terms)


### PR DESCRIPTION
## Summary
- Added Contact page in English (`/en/contact`) and Chinese (`/zh/contact`)
- Added 'Contact' / '联系我们' to top navigation in VitePress config
- Page includes: service description, invite code request instructions, pricing table, support contacts, partnership info, legal links