### PR TITLE
fix(ci): raise VitePress build heap to 8GB (unblock CF Pages)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "docs:dev": "cd docs && vitepress dev",
-    "docs:build": "cp -r assets/images docs/public/images && cd docs && NODE_OPTIONS='--max-old-space-size=3584' vitepress build",
+    "docs:build": "cp -r assets/images docs/public/images && cd docs && NODE_OPTIONS='--max-old-space-size=8192' vitepress build",
     "docs:preview": "cd docs && vitepress preview"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Cloudflare Pages production builds for #94/#95 fail; live site stuck at doc_count **625** while main has **665**.
- Local `vitepress build` RSS pegs at ~3.5GB under current `NODE_OPTIONS=3584` and never finishes bundles.
- Bump `docs:build` heap to **8192** so CF/local can complete.

## Test plan
- [ ] Validate green
- [ ] CF Pages production success on merge
- [ ] Live `docs.team-ra.org/zh/nmpa/guidance.html` shows 共 665 篇